### PR TITLE
Debug streamlit length error and find input fields

### DIFF
--- a/src/utils.py
+++ b/src/utils.py
@@ -36,7 +36,10 @@ def find_arrays(schema: Dict[str, Dict]) -> List[Dict]:
                 'path': path,
                 'full_path': details['full_path'],
                 'array_hierarchy': details['array_hierarchy'],
-                'depth': details['depth']
+                'depth': details['depth'],
+                'length': details.get('array_length', 0),  # Fix for the length error
+                'item_type': details.get('item_type', 'unknown'),  # Add item_type
+                'parent_arrays': details['array_hierarchy']  # Add parent_arrays mapping
             })
     return sorted(arrays, key=lambda x: x['depth'])
 


### PR DESCRIPTION
Add missing keys to array dictionary in `find_arrays` to fix `KeyError: 'length'` and provide complete array information.

---
<a href="https://cursor.com/background-agent?bcId=bc-15f92963-b458-4b95-be6f-151b3e465bbb">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-15f92963-b458-4b95-be6f-151b3e465bbb">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

