### PR TITLE
Investigate in_array application error

### DIFF
--- a/src/utils.py
+++ b/src/utils.py
@@ -72,6 +72,7 @@ def find_queryable_fields(schema: Dict[str, Dict]) -> List[Dict]:
                 'snowflake_type': details['snowflake_type'],
                 'array_hierarchy': details['array_hierarchy'],
                 'depth': details['depth'],
+                'in_array': details.get('is_array_item', False),  # Add missing in_array field
                 'sample_value': details.get('sample_value', 'N/A')
             })
     return sorted(queryable_fields, key=lambda x: (x['depth'], x['path']))


### PR DESCRIPTION
Add missing `in_array` field to queryable fields to resolve 'Application Error: 'in_array''.

---
<a href="https://cursor.com/background-agent?bcId=bc-643624bb-24c5-4b16-b5a1-e74bf4e6a52a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-643624bb-24c5-4b16-b5a1-e74bf4e6a52a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

